### PR TITLE
Fix ValueError crash

### DIFF
--- a/software/game.py
+++ b/software/game.py
@@ -112,7 +112,7 @@ class game_data:
                         self.myclue=row[1]
                         #print(self.myclue,row[2],self.signature)
                         #todo: this should be added to game files as row[2]
-                        self.signature=a2b_base64(row[2])
+                        #self.signature=a2b_base64(row[2])
                         self.signature=row[2]
                         #self.signature="none
                     elif row[0] == "#":


### PR DESCRIPTION
Line 115 in game.py causes a persistent `ValueError` crash & is redundant as `self.signature` is reassigned on the next line anyway.

Steps to reproduce on my badge:
- Settings > Advance game to Game#4